### PR TITLE
fix: zx2c4 dependency; add test for snmp_trap

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -483,4 +483,3 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
-replace golang.zx2c4.com/go118/netip v0.0.0-20211111135330-a4a02eeacf9d => git.zx2c4.com/go118-netip.git v0.0.0-20211111135330-a4a02eeacf9d

--- a/go.mod
+++ b/go.mod
@@ -483,3 +483,4 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
+replace golang.zx2c4.com/go118/netip v0.0.0-20211111135330-a4a02eeacf9d => git.zx2c4.com/go118-netip.git v0.0.0-20211111135330-a4a02eeacf9d

--- a/go.sum
+++ b/go.sum
@@ -57,6 +57,8 @@ collectd.org v0.5.0 h1:y4uFSAuOmeVhG3GCRa3/oH+ysePfO/+eGJNfd0Qa3d8=
 collectd.org v0.5.0/go.mod h1:A/8DzQBkF6abtvrT2j/AU/4tiBgJWYyh0y/oB/4MlWE=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 gioui.org v0.0.0-20210308172011-57750fc8a0a6/go.mod h1:RSH6KIUZ0p2xy5zHDxgAM4zumjgTw83q2ge/PI+yyw8=
+git.zx2c4.com/go118-netip.git v0.0.0-20211111135330-a4a02eeacf9d h1:3xvY7KpmfdDTyW91j5odVAkAM808BjhYs0zSwoyCoUI=
+git.zx2c4.com/go118-netip.git v0.0.0-20211111135330-a4a02eeacf9d/go.mod h1:5yyfuiqVIJ7t+3MqrpTQ+QqRkMWiESiyDvPNvKYCecg=
 github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4 h1:/vQbFIOMbk2FiG/kXiLl8BRyzTWDw7gX/Hz7Dd5eDMs=
 github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4/go.mod h1:hN7oaIRCjzsZ2dE+yG5k+rsdt3qcwykqK6HVGcKwsw4=
 github.com/99designs/keyring v1.2.2 h1:pZd3neh/EmUzWONb35LxQfvuY7kiSXAq3HQd97+XBn0=
@@ -2027,7 +2029,7 @@ golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 h1:H2TDz8ibqkAF6YGhCdN3jS9O0/s90v0rJh3X/OLHEUk=
 golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=
-golang.zx2c4.com/go118/netip v0.0.0-20211111135330-a4a02eeacf9d/go.mod h1:5yyfuiqVIJ7t+3MqrpTQ+QqRkMWiESiyDvPNvKYCecg=
+golang.zx2c4.com/go118-netip v0.0.0-20211111135330-a4a02eeacf9d/go.mod h1:5yyfuiqVIJ7t+3MqrpTQ+QqRkMWiESiyDvPNvKYCecg=
 golang.zx2c4.com/wintun v0.0.0-20211104114900-415007cec224/go.mod h1:deeaetjYA+DHMHg+sMSMI58GrEteJUUzzw7en6TJQcI=
 golang.zx2c4.com/wireguard v0.0.0-20211129173154-2dd424e2d808/go.mod h1:TjUWrnD5ATh7bFvmm/ALEJZQ4ivKbETb6pmyj1vUoNI=
 golang.zx2c4.com/wireguard v0.0.0-20211209221555-9c9e7e272434 h1:3zl8RkJNQ8wfPRomwv/6DBbH2Ut6dgMaWTxM0ZunWnE=

--- a/plugins/inputs/snmp_trap/snmp_trap_test.go
+++ b/plugins/inputs/snmp_trap/snmp_trap_test.go
@@ -1598,12 +1598,12 @@ func TestReceiveTrapMultipleConfig(t *testing.T) {
 				//if cold start be answer otherwise err
 				Log:          testutil.Logger{},
 				Version:      tt.version.String(),
-				SecName:      config.NewSecret([]byte(tt.secName+"1")),
+				SecName:      config.NewSecret([]byte(tt.secName + "1")),
 				SecLevel:     tt.secLevel,
 				AuthProtocol: tt.authProto,
-				AuthPassword: config.NewSecret([]byte(tt.authPass+"1")),
+				AuthPassword: config.NewSecret([]byte(tt.authPass + "1")),
 				PrivProtocol: tt.privProto,
-				PrivPassword: config.NewSecret([]byte(tt.privPass+"1")),
+				PrivPassword: config.NewSecret([]byte(tt.privPass + "1")),
 				Translator:   "netsnmp",
 			}
 
@@ -1617,7 +1617,7 @@ func TestReceiveTrapMultipleConfig(t *testing.T) {
 			var acc testutil.Accumulator
 			require.NoError(t, s.Start(&acc))
 			require.NoError(t, ss.Start(&acc))
-			
+
 			defer s.Stop()
 			defer ss.Stop()
 

--- a/plugins/inputs/snmp_trap/snmp_trap_test.go
+++ b/plugins/inputs/snmp_trap/snmp_trap_test.go
@@ -1319,3 +1319,331 @@ func TestReceiveTrap(t *testing.T) {
 		})
 	}
 }
+func TestReceiveTrapMultipleConfig(t *testing.T) {
+	now := uint32(123123123)
+	fakeTime := time.Unix(456456456, 456)
+
+	// If the first pdu isn't type TimeTicks, gosnmp.SendTrap() will
+	// prepend one with time.Now()
+	var tests = []struct {
+		name string
+
+		// send
+		version gosnmp.SnmpVersion
+		trap    gosnmp.SnmpTrap // include pdus
+		// V3 auth and priv parameters
+		secName   string // v3 username
+		secLevel  string // v3 security level
+		authProto string // Auth protocol: "", MD5 or SHA
+		authPass  string // Auth passphrase
+		privProto string // Priv protocol: "", DES or AES
+		privPass  string // Priv passphrase
+
+		// V3 sender context
+		contextName string
+		engineID    string
+
+		// receive
+		entries []entry
+		metrics []telegraf.Metric
+	}{
+		//ordinary v3 coldStart SHA trap auth and AES priv
+		{
+			name:      "v3 coldStart authSHAPrivAES",
+			version:   gosnmp.Version3,
+			secName:   "authSHAPrivAES",
+			secLevel:  "authPriv",
+			authProto: "SHA",
+			authPass:  "passpass",
+			privProto: "AES",
+			privPass:  "passpass",
+			trap: gosnmp.SnmpTrap{
+				Variables: []gosnmp.SnmpPDU{
+					{
+						Name:  ".1.3.6.1.2.1.1.3.0",
+						Type:  gosnmp.TimeTicks,
+						Value: now,
+					},
+					{
+						Name:  ".1.3.6.1.6.3.1.1.4.1.0", // SNMPv2-MIB::snmpTrapOID.0
+						Type:  gosnmp.ObjectIdentifier,
+						Value: ".1.3.6.1.6.3.1.1.5.1", // coldStart
+					},
+				},
+			},
+			entries: []entry{
+				{
+					oid: ".1.3.6.1.6.3.1.1.4.1.0",
+					e: snmp.MibEntry{
+						MibName: "SNMPv2-MIB",
+						OidText: "snmpTrapOID.0",
+					},
+				},
+				{
+					oid: ".1.3.6.1.6.3.1.1.5.1",
+					e: snmp.MibEntry{
+						MibName: "SNMPv2-MIB",
+						OidText: "coldStart",
+					},
+				},
+				{
+					oid: ".1.3.6.1.2.1.1.3.0",
+					e: snmp.MibEntry{
+						MibName: "UNUSED_MIB_NAME",
+						OidText: "sysUpTimeInstance",
+					},
+				},
+			},
+			metrics: []telegraf.Metric{
+				testutil.MustMetric(
+					"snmp_trap", // name
+					map[string]string{ // tags
+						"oid":     ".1.3.6.1.6.3.1.1.5.1",
+						"name":    "coldStart",
+						"mib":     "SNMPv2-MIB",
+						"version": "3",
+						"source":  "127.0.0.1",
+					},
+					map[string]interface{}{ // fields
+						"sysUpTimeInstance": now,
+					},
+					fakeTime,
+				),
+			},
+		},
+		//ordinary v3 coldStart SHA trap auth and AES256 priv
+		{
+			name:      "v3 coldStart authSHAPrivAES256",
+			version:   gosnmp.Version3,
+			secName:   "authSHAPrivAES256",
+			secLevel:  "authPriv",
+			authProto: "SHA",
+			authPass:  "passpass",
+			privProto: "AES256",
+			privPass:  "passpass",
+			trap: gosnmp.SnmpTrap{
+				Variables: []gosnmp.SnmpPDU{
+					{
+						Name:  ".1.3.6.1.2.1.1.3.0",
+						Type:  gosnmp.TimeTicks,
+						Value: now,
+					},
+					{
+						Name:  ".1.3.6.1.6.3.1.1.4.1.0", // SNMPv2-MIB::snmpTrapOID.0
+						Type:  gosnmp.ObjectIdentifier,
+						Value: ".1.3.6.1.6.3.1.1.5.1", // coldStart
+					},
+				},
+			},
+			entries: []entry{
+				{
+					oid: ".1.3.6.1.6.3.1.1.4.1.0",
+					e: snmp.MibEntry{
+						MibName: "SNMPv2-MIB",
+						OidText: "snmpTrapOID.0",
+					},
+				},
+				{
+					oid: ".1.3.6.1.6.3.1.1.5.1",
+					e: snmp.MibEntry{
+						MibName: "SNMPv2-MIB",
+						OidText: "coldStart",
+					},
+				},
+				{
+					oid: ".1.3.6.1.2.1.1.3.0",
+					e: snmp.MibEntry{
+						MibName: "UNUSED_MIB_NAME",
+						OidText: "sysUpTimeInstance",
+					},
+				},
+			},
+			metrics: []telegraf.Metric{
+				testutil.MustMetric(
+					"snmp_trap", // name
+					map[string]string{ // tags
+						"oid":     ".1.3.6.1.6.3.1.1.5.1",
+						"name":    "coldStart",
+						"mib":     "SNMPv2-MIB",
+						"version": "3",
+						"source":  "127.0.0.1",
+					},
+					map[string]interface{}{ // fields
+						"sysUpTimeInstance": now,
+					},
+					fakeTime,
+				),
+			},
+		},
+		//ordinary v3 coldStart SHA trap auth and AES256C priv
+		{
+			name:      "v3 coldStart authSHAPrivAES256C",
+			version:   gosnmp.Version3,
+			secName:   "authSHAPrivAES256C",
+			secLevel:  "authPriv",
+			authProto: "SHA",
+			authPass:  "passpass",
+			privProto: "AES256C",
+			privPass:  "passpass",
+			trap: gosnmp.SnmpTrap{
+				Variables: []gosnmp.SnmpPDU{
+					{
+						Name:  ".1.3.6.1.2.1.1.3.0",
+						Type:  gosnmp.TimeTicks,
+						Value: now,
+					},
+					{
+						Name:  ".1.3.6.1.6.3.1.1.4.1.0", // SNMPv2-MIB::snmpTrapOID.0
+						Type:  gosnmp.ObjectIdentifier,
+						Value: ".1.3.6.1.6.3.1.1.5.1", // coldStart
+					},
+				},
+			},
+			entries: []entry{
+				{
+					oid: ".1.3.6.1.6.3.1.1.4.1.0",
+					e: snmp.MibEntry{
+						MibName: "SNMPv2-MIB",
+						OidText: "snmpTrapOID.0",
+					},
+				},
+				{
+					oid: ".1.3.6.1.6.3.1.1.5.1",
+					e: snmp.MibEntry{
+						MibName: "SNMPv2-MIB",
+						OidText: "coldStart",
+					},
+				},
+				{
+					oid: ".1.3.6.1.2.1.1.3.0",
+					e: snmp.MibEntry{
+						MibName: "UNUSED_MIB_NAME",
+						OidText: "sysUpTimeInstance",
+					},
+				},
+			},
+			metrics: []telegraf.Metric{
+				testutil.MustMetric(
+					"snmp_trap", // name
+					map[string]string{ // tags
+						"oid":     ".1.3.6.1.6.3.1.1.5.1",
+						"name":    "coldStart",
+						"mib":     "SNMPv2-MIB",
+						"version": "3",
+						"source":  "127.0.0.1",
+					},
+					map[string]interface{}{ // fields
+						"sysUpTimeInstance": now,
+					},
+					fakeTime,
+				),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// We would prefer to specify port 0 and let the network
+			// stack choose an unused port for us but TrapListener
+			// doesn't have a way to return the autoselected port.
+			// Instead, we'll use an unusual port and hope it's
+			// unused.
+			const port = 12399
+
+			// Hook into the trap handler so the test knows when the
+			// trap has been received
+			received := make(chan int)
+			wrap := func(f gosnmp.TrapHandlerFunc) gosnmp.TrapHandlerFunc {
+				return func(p *gosnmp.SnmpPacket, a *net.UDPAddr) {
+					f(p, a)
+					received <- 0
+				}
+			}
+
+			// Set up the service input plugin
+			s := &SnmpTrap{
+				ServiceAddress:     "udp://:" + strconv.Itoa(port),
+				makeHandlerWrapper: wrap,
+				timeFunc: func() time.Time {
+					return fakeTime
+				},
+				//if cold start be answer otherwise err
+				Log:          testutil.Logger{},
+				Version:      tt.version.String(),
+				SecName:      config.NewSecret([]byte(tt.secName)),
+				SecLevel:     tt.secLevel,
+				AuthProtocol: tt.authProto,
+				AuthPassword: config.NewSecret([]byte(tt.authPass)),
+				PrivProtocol: tt.privProto,
+				PrivPassword: config.NewSecret([]byte(tt.privPass)),
+				Translator:   "netsnmp",
+			}
+
+			// Hook into the trap handler so the test knows when the
+			// trap has been received
+			receiveds := make(chan int)
+			wraps := func(f gosnmp.TrapHandlerFunc) gosnmp.TrapHandlerFunc {
+				return func(p *gosnmp.SnmpPacket, a *net.UDPAddr) {
+					f(p, a)
+					receiveds <- 0
+				}
+			}
+
+			// Set up a second service input plugin
+			ss := &SnmpTrap{
+				ServiceAddress:     "udp://:" + strconv.Itoa(port+1),
+				makeHandlerWrapper: wraps,
+				timeFunc: func() time.Time {
+					return fakeTime
+				},
+				//if cold start be answer otherwise err
+				Log:          testutil.Logger{},
+				Version:      tt.version.String(),
+				SecName:      config.NewSecret([]byte(tt.secName+"1")),
+				SecLevel:     tt.secLevel,
+				AuthProtocol: tt.authProto,
+				AuthPassword: config.NewSecret([]byte(tt.authPass+"1")),
+				PrivProtocol: tt.privProto,
+				PrivPassword: config.NewSecret([]byte(tt.privPass+"1")),
+				Translator:   "netsnmp",
+			}
+
+			require.NoError(t, s.Init())
+			require.NoError(t, ss.Init())
+
+			//inject test translator
+			s.transl = newTestTranslator(tt.entries)
+			//s.transl = newTestTranslator(tt.entries)	// not sure if this needed
+
+			var acc testutil.Accumulator
+			require.NoError(t, s.Start(&acc))
+			require.NoError(t, ss.Start(&acc))
+			
+			defer s.Stop()
+			defer ss.Stop()
+
+			var goSNMP gosnmp.GoSNMP
+			if tt.version == gosnmp.Version3 {
+				msgFlags := newMsgFlagsV3(tt.secLevel)
+				sp := newUsmSecurityParametersForV3(tt.authProto, tt.privProto, tt.secName, tt.privPass, tt.authPass)
+				goSNMP = newGoSNMPV3(port, tt.contextName, tt.engineID, msgFlags, sp)
+			} else {
+				goSNMP = newGoSNMP(tt.version, port)
+			}
+
+			// Send the trap
+			sendTrap(t, goSNMP, tt.trap)
+
+			// Wait for trap to be received
+			select {
+			case <-received:
+			case <-time.After(2 * time.Second):
+				t.Fatal("timed out waiting for trap to be received")
+			}
+
+			// Verify plugin output
+			testutil.RequireMetricsEqual(t,
+				tt.metrics, acc.GetTelegrafMetrics(),
+				testutil.SortMetrics())
+		})
+	}
+}


### PR DESCRIPTION
# Required for all PRs

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

golang.zx2c4.com/wireguard/wgctrl wants to pull in golang.zx2c4.com/go118/netip, which doesn't seem to exist as a go package any more. Add a "replacement" to go.mod to use the git repo URL instead.

the snmp_trap input doesn't have a test for when multiple listeners are configured. add a very basic check using a subset of the existing tests. for each trap to test, create two listeners, the second of which has the same secrets but with a "1" added to them.